### PR TITLE
Exclude tests from find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/MrDogeBro/sphinx_rtd_dark_mode",
     download_url=f"https://github.com/MrDogeBro/sphinx_rtd_dark_mode/archive/v{sphinx_rtd_dark_mode.__version__}.tar.gz",
-    packages=setuptools.find_packages(exclude=["tests*"]),
+    packages=setuptools.find_packages(exclude=["tests"]),
     package_data={
         "sphinx_rtd_dark_mode": [
             "static/dark_mode_css/general.css",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/MrDogeBro/sphinx_rtd_dark_mode",
     download_url=f"https://github.com/MrDogeBro/sphinx_rtd_dark_mode/archive/v{sphinx_rtd_dark_mode.__version__}.tar.gz",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests*"]),
     package_data={
         "sphinx_rtd_dark_mode": [
             "static/dark_mode_css/general.css",


### PR DESCRIPTION
closes #25

Removes `tests/__init__.py` and `tests/build.py` files that leads
`find_packages` to treating `tests` as a package dir, which will prevent
a user of `sphinx_rtd_dark_mode` from importing from a repo-local test
directory.