### PR TITLE
Fixes styling of general admonitions (fixes #35)

### DIFF
--- a/sphinx_rtd_dark_mode/static/dark_mode_css/dark.css
+++ b/sphinx_rtd_dark_mode/static/dark_mode_css/dark.css
@@ -264,6 +264,7 @@ html[data-theme='dark'] .wy-alert.wy-alert-success .wy-alert-title {
   background-color: #006a56;
 }
 
+html[data-theme='dark'] .rst-content .admonition,
 html[data-theme='dark'] .rst-content .note,
 html[data-theme='dark'] .rst-content .seealso,
 html[data-theme='dark'] .rst-content .wy-alert-info.admonition,
@@ -280,6 +281,7 @@ html[data-theme='dark'] .wy-alert.wy-alert-info {
   background-color: #002c4d;
 }
 
+html[data-theme='dark'] .rst-content .admonition .admonition-title,
 html[data-theme='dark'] .rst-content .note .admonition-title,
 html[data-theme='dark'] .rst-content .note .wy-alert-title,
 html[data-theme='dark'] .rst-content .seealso .admonition-title,

--- a/tests/preview-build/test.rst
+++ b/tests/preview-build/test.rst
@@ -37,6 +37,10 @@ Test Directives
 
     Testing
 
+.. admonition:: Admonition
+
+    Testing
+
 .. rubric:: Testing
 
 .. centered:: Testing


### PR DESCRIPTION
With this PR, the example in #35 renders like this:

![Snag_b94f93](https://user-images.githubusercontent.com/98736054/199004122-50b9a22d-717c-4a48-8f8d-e89f24edd691.png)
