### PR TITLE
Fixes styling of emphasized lines (fixes #37)

### DIFF
--- a/sphinx_rtd_dark_mode/static/dark_mode_css/dark.css
+++ b/sphinx_rtd_dark_mode/static/dark_mode_css/dark.css
@@ -50,6 +50,10 @@ html[data-theme='dark'] .highlight .c1 {
   color: #686868;
 }
 
+html[data-theme='dark'] .highlight .hll {
+  background-color: #002c4d;
+}
+
 html[data-theme='dark'] .rst-content div[class^='highlight'] {
   border-color: #1a1a1a;
 }

--- a/tests/preview-build/test.rst
+++ b/tests/preview-build/test.rst
@@ -71,6 +71,9 @@ Test Code Blocks
 ----------------
 
 .. code-block:: python
+    :caption: Python code with emphasized lines
+    :linenos:
+    :emphasize-lines: 8-9
 
     from content_filter import Filter
 


### PR DESCRIPTION
With this PR, the example in #37 is rendered as:

![Snag_131b039](https://user-images.githubusercontent.com/98736054/199029165-deea9100-4e5c-4e57-b2f0-a07d77d48b07.png)
