### PR TITLE
Add Sphinx Extension classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
     license=sphinx_rtd_dark_mode.__license__,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
+        "Framework :: Sphinx :: Extension",
         "Natural Language :: English",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).