### PR TITLE
Added styles for css classes used in api documentations

### DIFF
--- a/sphinx_rtd_dark_mode/static/dark_mode_css/dark.css
+++ b/sphinx_rtd_dark_mode/static/dark_mode_css/dark.css
@@ -518,3 +518,19 @@ html[data-theme="dark"] .guilabel {
   background-color: #343434;
   border-color: #4d4d4d;
 }
+
+html[data-theme="dark"] .sig.sig-object {
+  border-left-color: #3e4446 !important;
+  background-color: #202325 !important
+}
+
+html[data-theme="dark"] .property,
+html[data-theme="dark"] .optional,
+html[data-theme="dark"] .sig-name,
+html[data-theme="dark"] .sig-param,
+html[data-theme="dark"] .sig-paren,
+html[data-theme="dark"] .sig-prename,
+html[data-theme="dark"] .sig-return-icon,
+html[data-theme="dark"] .sig-return-typehint {
+  color: #e8e6e3 !important
+}


### PR DESCRIPTION
Hi. I am raising this PR to add additional styles for classes used in API documentation using RTD's theme. I have pasted the screenshot after using additional styles used in this PR and it can be compared to the screenshot shared in issue #47 

![image](https://github.com/user-attachments/assets/1059604b-1d5b-4565-b26e-e6421d61e6ac)