### PR TITLE
fix(colors): fix 5 pigments highlight colors that were otherwise unreadable

### DIFF
--- a/sphinx_rtd_dark_mode/static/dark_mode_css/dark.css
+++ b/sphinx_rtd_dark_mode/static/dark_mode_css/dark.css
@@ -40,7 +40,7 @@ html[data-theme="dark"] .highlight .nf {
 }
 
 html[data-theme="dark"] .highlight .nl {
-  color: #003dd0;
+  color: #0043e2;
 }
 
 html[data-theme="dark"] .highlight .kn,

--- a/sphinx_rtd_dark_mode/static/dark_mode_css/dark.css
+++ b/sphinx_rtd_dark_mode/static/dark_mode_css/dark.css
@@ -35,6 +35,14 @@ html[data-theme="dark"] .highlight .nv {
   color: #40ffff;
 }
 
+html[data-theme="dark"] .highlight .nf {
+  color: #3569f5;
+}
+
+html[data-theme="dark"] .highlight .nl {
+  color: #003dd0;
+}
+
 html[data-theme="dark"] .highlight .kn,
 html[data-theme="dark"] .highlight .kc,
 html[data-theme="dark"] .highlight .k {

--- a/sphinx_rtd_dark_mode/static/dark_mode_css/dark.css
+++ b/sphinx_rtd_dark_mode/static/dark_mode_css/dark.css
@@ -20,7 +20,7 @@ html[data-theme="dark"] .section {
 }
 
 html[data-theme="dark"] .highlight {
-  background-color: #17181c;
+  background-color: #ffffff; color: #bfbfbf
 }
 
 html[data-theme="dark"] .highlight .nn {
@@ -41,6 +41,14 @@ html[data-theme="dark"] .highlight .nf {
 
 html[data-theme="dark"] .highlight .nl {
   color: #0043e2;
+}
+
+html[data-theme="dark"] .descname .n {
+  color: #0a44de;
+}
+
+html[data-theme="dark"] .highlight .p {
+  color: #5c7c72
 }
 
 html[data-theme="dark"] .highlight .kn,


### PR DESCRIPTION
This is described in Issue #48:  five colors from `pygments.css` C-code highlighting were unreadable in dark mode (function names and label names, names, punctuation, and plain text highlighting).  Screenshots are shown in Issue #48.

This addition to `dark.css` remedies both by lightening the default `pygments.css` colors just enough to be nicely readable against the dark background, without changing their angle on the color wheel.

Resolves #48