### PR TITLE
Revert "Exclude tests from find_packages"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/MrDogeBro/sphinx_rtd_dark_mode",
     download_url=f"https://github.com/MrDogeBro/sphinx_rtd_dark_mode/archive/v{sphinx_rtd_dark_mode.__version__}.tar.gz",
-    packages=setuptools.find_packages(exclude=["tests"]),
+    packages=setuptools.find_packages(),
     package_data={
         "sphinx_rtd_dark_mode": [
             "static/dark_mode_css/general.css",


### PR DESCRIPTION
html.writer-html4 .rst-content dl:not(.docutils) .descclassname,html.writer-html4 .rst-content dl:not(.docutils) .descname,html.writer-html4 .rst-content dl:not(.docutils) .sig-name,html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) .descclassname,html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) .descname,html.writer-html5 .rst-content dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.citation):not(.glossary):not(.simple) .sig-name{font-family:SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,Courier,monospace;color:#000}